### PR TITLE
Limit pytest to <4.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
        drf3.4: djangorestframework==3.4.7
        drf3.5: djangorestframework==3.5.1
        pytest-django==3.0.0
+       pytest<4.0.0
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Fixes the failing builds